### PR TITLE
fix crash if scan has no margins

### DIFF
--- a/filters/output/OutputGenerator.cpp
+++ b/filters/output/OutputGenerator.cpp
@@ -245,8 +245,8 @@ OutputGenerator::OutputGenerator(
 :	m_dpi(dpi),
 	m_colorParams(color_params),
 	m_xform(xform),
-	m_outRect(xform.resultingRect().toRect()),
-	m_contentRect(xform.transform().map(content_rect_phys).boundingRect().toRect()),
+	m_outRect(xform.resultingRect().toAlignedRect()),
+	m_contentRect(xform.transform().map(content_rect_phys).boundingRect().toAlignedRect()),
 	m_despeckleLevel(despeckle_level)
 {	
 	assert(m_outRect.topLeft() == QPoint(0, 0));


### PR DESCRIPTION
It crashes on line 255.

The problem must be with rounding rectangles in float coordinates to rectangles in integer coordinates. In some circumstances it rounds to -1 pixel for output rect and to +1 pixel for working rect. Working rect size becomes 1 pixel bigger than output page size and everything collapses. And non-zero margins seems to save ST from that. toAlignedRect() is using ceil() instead of round() for float coordinates conversion so the sizes should always match.